### PR TITLE
Switch code block leader check from nil to empty

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -392,11 +392,11 @@ module CLIMarkdown
 
       input.gsub!(/(?i-m)([`~]{3,})([\s\S]*?)\n([\s\S]*?)\1/ ) do |cb|
         m = Regexp.last_match
-        leader = m[2] ? m[2].upcase + ":" : 'CODE:'
+        leader = !m[2].empty? ? m[2].upcase + ":" : 'CODE:'
         leader += xc
 
         if exec_available('pygmentize')
-          lexer = m[2].nil? ? '-g' : "-l #{m[2]}"
+          lexer = m[2].empty? ? '-g' : "-l #{m[2]}"
           begin
             hilite, s = Open3.capture2(%Q{pygmentize #{lexer} 2> /dev/null}, :stdin_data=>m[3])
 


### PR DESCRIPTION
Checking that the code block is nil never fails and the code blocks
without any specified language are ultimately not displayed. Changing
this to use an empty?-check instead makes the block appear with "CODE:"
prefix and without any syntax highlighting, as expected.